### PR TITLE
Add the U32 Version payload to the 0x0D VERSION messages

### DIFF
--- a/lib/frame-builder.js
+++ b/lib/frame-builder.js
@@ -183,7 +183,7 @@ frame_builder[C.FRAME_TYPE.READ_PARAMETER] = function(frame, builder) {
 };
 
 frame_builder[C.FRAME_TYPE.VERSION] = function(_frame, builder) {
-  builder.appendUint32LE(0);
+  builder.appendUInt32LE(0);
 };
 
 frame_builder[C.FRAME_TYPE.WRITE_PARAMETER] = function(frame, builder) {

--- a/lib/frame-builder.js
+++ b/lib/frame-builder.js
@@ -182,7 +182,8 @@ frame_builder[C.FRAME_TYPE.READ_PARAMETER] = function(frame, builder) {
   }
 };
 
-frame_builder[C.FRAME_TYPE.VERSION] = function(_frame, _builder) {
+frame_builder[C.FRAME_TYPE.VERSION] = function(_frame, builder) {
+  builder.appendUint32LE(0);
 };
 
 frame_builder[C.FRAME_TYPE.WRITE_PARAMETER] = function(frame, builder) {


### PR DESCRIPTION
Part 1 (of 2) of handling the latest deconz firmware

Original code from @frederic34 in https://github.com/WebThingsIO/serial-prober-node/issues/11#issuecomment-736284238

From reading the spec at page 9 of
https://deconz.dresden-elektronik.de/raspbian/deCONZ-Serial-Protocol-en_1.14.pdf
this should already have been present since at least 2019.
Apparently the newer firmware is more strict and checks message lengths,
rejecting messages for incorrect formats.